### PR TITLE
Multiple audio sources extra

### DIFF
--- a/@types/types.d.ts
+++ b/@types/types.d.ts
@@ -140,6 +140,7 @@ type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U]
 type AudioSources = {
 	youtube: Array<TrackYoutubeSource>
 	subsonic: TrackSource
+	soundcloud: any
 }
 
 interface GooseConfig {

--- a/@types/types.d.ts
+++ b/@types/types.d.ts
@@ -140,7 +140,6 @@ type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U]
 type AudioSources = {
 	youtube: Array<TrackYoutubeSource>
 	subsonic: TrackSource
-	soundcloud: any
 }
 
 interface GooseConfig {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,10 @@ import { StatusBar } from './StatusBar';
 import { MediaBar } from './MediaBar';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import styled, { css } from 'styled-components';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import DisplaySelect from './DisplaySelect';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { DropCheck } from './DropCheck';
 
 import { allowExternal, allowedExternalTypes } from './utils';
 
@@ -59,7 +62,7 @@ export default class App extends React.Component<Record<string, never>, AppState
         'Content-Type': 'application/json',
       },
     }).then((response) => response.json()).then((json) => {
-      console.log(`fetch response ${Date.now()}`);
+      // console.log(`fetch response ${Date.now()}`);
       // spite
       json && Object.keys(json).map((key:string) => {
         switch (key) {
@@ -97,19 +100,20 @@ export default class App extends React.Component<Record<string, never>, AppState
       const socket = new WebSocket(`${protocol}://${window.location.hostname}:${window.location.port}/websocket`); // this is not a problem
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       socket.addEventListener('open', (event: any) => {
-        console.log(`WebSocket open: ${JSON.stringify(event, null, 2)}`);
+        // console.log(`WebSocket open: ${JSON.stringify(event, null, 2)}`);
       });
       socket.addEventListener('error', (event: any) => {
         console.log(`WebSocket error: ${JSON.stringify(event, null, 2)}`);
       });
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       socket.addEventListener('close', (event: any) => {
-        console.log(`WebSocket close: ${JSON.stringify(event, null, 2)}`);
+        // console.log(`WebSocket close: ${JSON.stringify(event, null, 2)}`);
       });
       socket.addEventListener('message', (event: any) => {
         const data = JSON.parse(event.data);
         switch (data.type) {
           case 'playerStatus': {
-            console.log(`socket status update ${Date.now()}`);
+            // console.log(`socket status update ${Date.now()}`);
             this.setState({ playerStatus: data.queue });
             break;
           }
@@ -146,7 +150,7 @@ export default class App extends React.Component<Record<string, never>, AppState
             <DisplaySelect />
           </MainContent>
         </div>
-      );
+      ); // <DropCheck />
     }
   }
   // <MediaBar playerClick={this.playerClick} />
@@ -212,13 +216,13 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
 
   const shouldAllow = (event:React.DragEvent<HTMLElement>, internal:boolean) => {
     if (allowed !== null) {
-      console.log('queue allow, early exit');
+      // console.log('queue allow, early exit');
       return allowed;
     }
     let allow = internal;
     allow ||= allowExternal(event);
     if (allow) { setAllowed(allow); }
-    console.log(`should ${allow}`);
+    // console.log(`should ${allow}`);
     return allow;
   };
 
@@ -244,7 +248,7 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
 
   const serverQueue = props.status?.tracks;
   const localQueue:JSX.Element[] = React.useMemo(() => {
-    console.log('queue happening');
+    // console.log('queue happening');
     const queue = [];
     if (serverQueue) {
       for (const [i, track] of serverQueue.entries()) {
@@ -255,7 +259,7 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
   }, [serverQueue, props.playerClick, dragID]);
 
   React.useEffect(() => {
-    console.log(`serverqueue change ${Date.now()}`);
+    // console.log(`serverqueue change ${Date.now()}`);
     clearStyling();
     dispatchEvent(new CustomEvent('cleanup'));
   }, [serverQueue]);
@@ -277,14 +281,14 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
     if (!dropStyle.current) { return; } // not mounted; shouldn't be (possible to be) here
     const same = event.currentTarget === event.target;
     if (!same) { // shouldn't be possible currently, but may be again in future
-      console.log('queue enter handler—same: ' + same);
-      console.log(event);
+      // console.log('queue enter handler—same: ' + same);
+      // console.log(event);
       return;
     }
 
     const internal = event.dataTransfer.types.includes('application/x-goose.track');
     if (internal && dragID === localQueue.length - 1) {
-      console.log('queue enter, invalid');
+      // console.log('queue enter, invalid');
       dropStyle.current.style.borderTop = '2px solid #f800e3';
       dropStyle.current.style.opacity = '0.4';
       return;
@@ -302,7 +306,7 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
     // console.log(`over queue`);
     const internal = event.dataTransfer.types.includes('application/x-goose.track');
     if (internal && dragID === localQueue.length - 1) {
-      console.log('queue over, invalid');
+      // console.log('queue over, invalid');
       return;
     }
 
@@ -316,8 +320,8 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
     if (event.currentTarget === event.target) {
       clearStyling();
     } else { // shouldn't be possible currently, but may be again in future
-      console.log('queue enter handler—same: false');
-      console.log(event);
+      // console.log('queue enter handler—same: false');
+      // console.log(event);
       return;
     }
   };
@@ -349,13 +353,11 @@ function PlayerQueue(props: { playerClick:(action:PlayerClick) => void, status?:
     } else if (externalTypes.length === 0) {
       clearStyling();
       const types = event.dataTransfer.types.map(type => `\nkey: ${type},\n\tvalue: ${event.dataTransfer.getData(type)}`).toString();
-      console.log(`queue drop external, no valid external types. types: ${types}`);
-      return;
+      console.log(`queue drop external. no valid types in: ${types}`);
     } else {
       clearStyling();
       const types = event.dataTransfer.types.map(type => `\nkey: ${type},\n\tvalue: ${event.dataTransfer.getData(type)}`).toString();
-      console.log(`queue drop internal, no valid types. types: ${types}`);
-      return;
+      console.log(`queue drop. no valid types in: ${types}`);
     }
   };
 

--- a/client/src/DropCheck.tsx
+++ b/client/src/DropCheck.tsx
@@ -1,0 +1,124 @@
+import './App.css';
+import * as React from 'react';
+
+// standard disallows reading values of external types mid-drag; can only match keys
+const allowExternal = (event:React.DragEvent<HTMLElement>):boolean => { // used on dragOver event
+  return true; // comment out to play with tests below
+  const index = event.dataTransfer.types.findIndex((type) => typeof type === 'string'); // && dragPattern.test(type)
+  return (index !== -1);
+};
+
+// see https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types
+const allowedExternalTypes = (event:React.DragEvent<HTMLElement>) => { // used on drop event
+  return event.dataTransfer.types; // comment out to play with tests below
+  const allowed = event.dataTransfer.types.filter((type) => typeof type === 'string') // && dragPattern.test(type)
+    .map((type) => event.dataTransfer.getData(type))
+    .filter((type) => type); // anything truthy will be included, in this case using the key itself
+    // spotifyPattern.test(type) || subsonicPattern.test(type)
+
+  return (allowed);
+};
+
+export function DropCheck() {
+  const [allowed, setAllowed] = React.useState<boolean | null>(null);
+  const dropStyle = React.useRef<HTMLDivElement>(null);
+
+  const shouldAllow = (event:React.DragEvent<HTMLElement>, internal:boolean) => {
+    if (allowed !== null) {
+      return allowed;
+    }
+    let allow = internal;
+    allow ||= allowExternal(event);
+    if (allow) { setAllowed(allow); }
+    // console.log(`should ${allow}`);
+    return allow;
+  };
+
+  const clearStyling = () => {
+    if (dropStyle.current) {
+      dropStyle.current.style.border = 'unset';
+      dropStyle.current.style.opacity = 'unset';
+    }
+  };
+
+  const rejectDrop = () => {
+    dispatchEvent(new CustomEvent('cleanup'));
+    dispatchEvent(new CustomEvent('dragid', { detail: null }));
+  };
+
+  const dragEnd = (event:React.DragEvent<HTMLElement>) => {
+    event.currentTarget.style.opacity = 'initial';
+    if (event.dataTransfer.dropEffect === 'none') {
+      // app-origin, cancel
+    } else {
+      // app-origin, success
+    }
+  };
+
+  const dragEnter = (event:React.DragEvent<HTMLElement>) => {
+    if (!dropStyle.current) { return; } // not mounted; shouldn't be (possible to be) here
+
+    const internal = event.dataTransfer.types.includes('application/x-goose.track');
+    if (internal) {
+      //
+    }
+
+    if (internal || shouldAllow(event, internal)) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = (internal) ? 'move' : 'copy';
+      event.dataTransfer.effectAllowed = (internal) ? 'move' : 'copy';
+      dropStyle.current.style.border = '2px solid #f800e3';
+    }
+  };
+
+  const dragOver = (event:React.DragEvent<HTMLElement>) => {
+    const internal = event.dataTransfer.types.includes('application/x-goose.track');
+    if (internal) {
+      //
+    }
+
+    if (allowed || shouldAllow(event, internal)) {
+      event.preventDefault();
+    }
+  };
+
+  const dragLeave = (event:React.DragEvent<HTMLElement>) => {
+    setAllowed(null);
+    if (event.currentTarget === event.target) {
+      clearStyling();
+    }
+  };
+
+  const drop = (event:React.DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setAllowed(null);
+
+    // can/should vary by case (see PlayerQueue and TrackSmall for examples), but here generically the goal is just output
+    clearStyling();
+    rejectDrop();
+
+    const internal = event.dataTransfer.types.includes('application/x-goose.track');
+    const externalTypes:readonly string[] = (!internal) ? allowedExternalTypes(event) : [];
+    const types = event.dataTransfer.types.map(type => `\nkey: ${type},\n\tvalue: ${event.dataTransfer.getData(type)}`).toString();
+
+    // emphasis that I'm using externalTypes here only to see if the filters in place (if any, default extremely permissive) are allowing anything through
+    // but outputting all types for, hopefully, the convenience of seeing them when tweaking filters. consider printing/comparing externalTypes as needed
+    if (internal) {
+      // const value = JSON.parse(event.dataTransfer.getData('application/key-set-in-dragStart')) as TypeDefinition; // example; see TrackSmall dragStart
+      console.log(`drop check—internal. types: ${types}`);
+    } else if (externalTypes.length) {
+      console.log(`drop check—allowed external. types: ${types}`);
+    } else if (externalTypes.length === 0) {
+      console.log(`drop check—disallowed external. no valid types in: ${types}`);
+    } else {
+      console.log(`drop check—no valid types in: ${types}`);
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div className='dropzone' ref={dropStyle} style={{ flexGrow: 1, marginTop: '-1px' }} onDragEnd={dragEnd} onDragEnter={dragEnter} onDragOver={dragOver} onDragLeave={dragLeave} onDrop={drop} />
+    </div>
+  );
+}

--- a/client/src/TrackSmall.tsx
+++ b/client/src/TrackSmall.tsx
@@ -71,7 +71,7 @@ export function TrackSmall(props: { id:number, track:Track, playerClick:(action:
     nearerTop: false,
     nearerBottom: false,
   };
-  console.log('track happening');
+  // console.log('track happening');
 
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const [allowed, setAllowed] = React.useState<boolean | null>(null);
@@ -168,7 +168,7 @@ export function TrackSmall(props: { id:number, track:Track, playerClick:(action:
 
   const dragEnter = (event:React.DragEvent<HTMLElement>) => {
     event.stopPropagation();
-    console.log('track handler—enter');
+    // console.log('track handler—enter');
     // console.log(`drag entered track: ${props.id + 1}`);
     const internal = event.dataTransfer.types.includes('application/x-goose.track');
     if (allowed || shouldAllow(event, internal)) {
@@ -215,7 +215,7 @@ export function TrackSmall(props: { id:number, track:Track, playerClick:(action:
   const dragLeave = (event:React.DragEvent<HTMLElement>) => {
     event.stopPropagation();
     setAllowed(null);
-    console.log('track handler—leave');
+    // console.log('track handler—leave');
     const internal = event.dataTransfer.types.includes('application/x-goose.track');
     if (internal || allowExternal(event)) {
       // removeEventListener('cleanup', cleanUp);
@@ -248,15 +248,18 @@ export function TrackSmall(props: { id:number, track:Track, playerClick:(action:
         console.log(`move track: [${props.dragID}] ${from.name} to: [${to}], ${state.nearerTop ? 'above' : 'below'} [${props.id}] ${props.track.goose.track.name}`);
       }
     } else if (externalTypes.length) {
-      console.log(`external accepted: ${externalTypes}`);
+      // console.log(`external accepted: ${externalTypes}`);
       addEventListener('cleanup', cleanUp);
       const to = (state.nearerTop) ? props.id : props.id + 1;
       trackClick('pendingIndex', `${to} ${externalTypes[0]}`);
       console.log(`queue resource ${externalTypes} at position ${to}`);
     } else if (externalTypes.length === 0) {
-      console.log('no valid external types');
+      const types = event.dataTransfer.types.map(type => `\nkey: ${type},\n\tvalue: ${event.dataTransfer.getData(type)}`).toString();
+      console.log(`track external—no valid types in: ${types}`);
       rejectDrop();
     } else {
+      const types = event.dataTransfer.types.map(type => `\nkey: ${type},\n\tvalue: ${event.dataTransfer.getData(type)}`).toString();
+      console.log(`track—no valid types in: ${types}`);
       rejectDrop();
     }
   };

--- a/client/src/regexes.js
+++ b/client/src/regexes.js
@@ -2,5 +2,6 @@ export const youtubePattern = /(?:youtube\.com|youtu\.be)(\/(?:[\w-]+\?v=|embed\
 export const youtubePlaylistPattern = /(?:youtube\.com)(\/(?:playlist\?list=)?)([\w-]{34})(\S+)?/;
 export const spotifyPattern = /(?:spotify\.com|spotify)(?:\/|:)((?:track|playlist|album){1})(?:\/|:)([a-zA-Z0-9]{22})/;
 export const napsterPattern = /(?:play\.napster\.com)(?:\/album\/|\/playlist\/)((?:alb\.|pp\.|mp\.)(?:\d{9}){1}).*((?<=&rsrc=)(?:track|playlist|album){1})(?:&trackId=)?((?:tra\.\d{9}))?/;
+export const subsonicPattern = /(?:\/app\/#\/)((?:track|playlist|album){1})(?:\/)([a-f0-9-]{32,36})/;
 
 export const dragPattern = /(url)/i;

--- a/client/src/regexes.js
+++ b/client/src/regexes.js
@@ -4,4 +4,4 @@ export const spotifyPattern = /(?:spotify\.com|spotify)(?:\/|:)((?:track|playlis
 export const napsterPattern = /(?:play\.napster\.com)(?:\/album\/|\/playlist\/)((?:alb\.|pp\.|mp\.)(?:\d{9}){1}).*((?<=&rsrc=)(?:track|playlist|album){1})(?:&trackId=)?((?:tra\.\d{9}))?/;
 export const subsonicPattern = /(?:\/app\/#\/)((?:track|playlist|album){1})(?:\/)([a-f0-9-]{32,36})/;
 
-export const dragPattern = /(url)/i;
+export const dragPattern = /(text\/plain)/i;

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { dragPattern, youtubePattern, youtubePlaylistPattern, spotifyPattern, napsterPattern } from './regexes.js';
+import { dragPattern, youtubePattern, youtubePlaylistPattern, spotifyPattern, napsterPattern, subsonicPattern } from './regexes.js';
 
 export function timeDisplay(seconds:number) {
   let time = new Date(seconds * 1000).toISOString().substring(11, 19).replace(/^[0:]+/, '');
@@ -20,7 +20,7 @@ export const allowExternal = (event:React.DragEvent<HTMLElement>):boolean => {
 export const allowedExternalTypes = (event:React.DragEvent<HTMLElement>) => {
   const allowed = event.dataTransfer.types.filter((type) => typeof type === 'string' && dragPattern.test(type))
     .map((type) => event.dataTransfer.getData(type))
-    .filter((type) => spotifyPattern.test(type));
+    .filter((type) => spotifyPattern.test(type) || subsonicPattern.test(type));
   //  || youtubePlaylistPattern.test(type) || napsterPattern.test(type) || youtubePattern.test(type)
 
   return (allowed);

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -29,9 +29,7 @@ export const allowedExternalTypes = (event:React.DragEvent<HTMLElement>) => {
 export function chooseAudioSource(track:Track):TrackSource|TrackYoutubeSource {
   if (track.audioSource.subsonic) {
     return track.audioSource.subsonic;
-  } else if (track.audioSource.youtube) {
-    return track.audioSource.youtube[0];
   } else {
-    return track.audioSource.soundcloud;
+    return track.audioSource.youtube![0];
   }
 }

--- a/server/src/regexes.ts
+++ b/server/src/regexes.ts
@@ -32,4 +32,5 @@ export const subsonicPattern = /(?:\/app\/#\/)((?:track|playlist|album){1})(?:\/
 // [2] is the ID
 
 // I should definitely be allowed to write code that will ever see production
-export const subsonicPathExtractor = /(?:\(\?:)([a-z0-9-\\.:]+)(?:\))/;
+export const subsonicPathExtractor = /(?:\(\?:)([a-z0-9-\\.:|]+)(?:\))/;
+// export const subsonicPathExtractor = /(?:\(\?:)([a-z0-9-\\.:]+)(?:\))/;

--- a/server/src/regexes.ts
+++ b/server/src/regexes.ts
@@ -25,3 +25,11 @@ export const napsterPattern = /(?:play\.napster\.com)(?:\/album\/|\/playlist\/)(
 // [1] is the ID for albums and playlists
 // [2] is the link type - track, album, playlist
 // [3] is the ID for tracks
+
+export const subsonicPattern = /(?:\/app\/#\/)((?:track|playlist|album){1})(?:\/)([a-f0-9-]{32,36})/;
+// [0] is the original string
+// [1] is track, playlist, or album
+// [2] is the ID
+
+// I should definitely be allowed to write code that will ever see production
+export const subsonicPathExtractor = /(?:\(\?:)([a-z0-9-\\.:]+)(?:\))/;

--- a/server/src/webserver.ts
+++ b/server/src/webserver.ts
@@ -144,14 +144,24 @@ worker.on('message', async (message:WebWorkerMessage) => {
               query = `spotify.com/${match![1]}/${match![2]}`;
             } else if (shittifySubsonic.test(query)) {
               // yes
-              const path = subsonic.regex.match(subsonicPathExtractor);
-              if (!path || (path && !path.length)) {
+              const subsonicPaths = subsonic.regex.match(subsonicPathExtractor);
+              // logDebug(subsonicPaths);
+              if (!subsonicPaths || (subsonicPaths && !subsonicPaths.length)) {
                 logDebug('how could this fail');
                 worker.postMessage({ id:message.id, error: 'I\'ll fix this, uh, after an amount of time' });
                 return;
               }
+              // logDebug(query);
+              const clientPath = query.split(/(?:;)([a-z0-9-\\.:]+)(?:&)/)[1];
+              // logDebug(clientPath);
+
+              const path = subsonicPaths[1].split('|')
+                .map(paths => paths.replaceAll('\\', ''))
+                .filter(paths => paths == clientPath);
+              // logDebug(path);
+
               const match = query.match(shittifySubsonic);
-              query = `${path[1].replaceAll('\\', '')}/app/#/${match![1]}/${match![2]}`;
+              query = `${path}/app/#/${match![1]}/${match![2]}`;
               // logDebug(query);
               // logDebug(subsonicWorker.searchRegex.test(query));
             } else {

--- a/server/src/webserver.ts
+++ b/server/src/webserver.ts
@@ -142,28 +142,27 @@ worker.on('message', async (message:WebWorkerMessage) => {
             if (shittify.test(query)) {
               const match = query.match(shittify);
               query = `spotify.com/${match![1]}/${match![2]}`;
-            } else if (shittifySubsonic.test(query)) {
-              // yes
+            } else if (shittifySubsonic.test(query)) { // yes. this comment was funnier before it got worse
               const subsonicPaths = subsonic.regex.match(subsonicPathExtractor);
-              // logDebug(subsonicPaths);
+              // logDebug(`subsonic config paths are: ${subsonicPaths}`);
               if (!subsonicPaths || (subsonicPaths && !subsonicPaths.length)) {
                 logDebug('how could this fail');
                 worker.postMessage({ id:message.id, error: 'I\'ll fix this, uh, after an amount of time' });
                 return;
               }
-              // logDebug(query);
+              // logDebug(`sanitized client query is: ${query}`);
               const clientPath = query.split(/(?:;)([a-z0-9-\\.:]+)(?:&)/)[1];
-              // logDebug(clientPath);
+              // logDebug(`desired client path is: ${clientPath}`);
 
               const path = subsonicPaths[1].split('|')
                 .map(paths => paths.replaceAll('\\', ''))
                 .filter(paths => paths == clientPath);
-              // logDebug(path);
+              // logDebug(`client/server agree on path: ${path}`);
 
               const match = query.match(shittifySubsonic);
               query = `${path}/app/#/${match![1]}/${match![2]}`;
-              // logDebug(query);
-              // logDebug(subsonicWorker.searchRegex.test(query));
+              // logDebug(`query being sent to acquire is: ${query}`);
+              // logDebug(`query should pass acquire regex: ${subsonicWorker.searchRegex.test(query)}`);
             } else {
               logDebug(`webparent queue—shitty bandaid failed; ${query} does not match regex`);
               worker.postMessage({ id:message.id, error: 'I\'ll fix this once I sleep <3' });


### PR DESCRIPTION
Adds Navidrome/subsonic drag and drop support. Currently limited to albums/playlists because tracks are being improperly serialized by the frontend [object Object]; will likely automatically work for tracks if/when that's addressed.

Can now drag and drop from the Spotify browser client as well.

And adds a minor utility for exploring the types of dragged objects.