### PR TITLE
Acquire error feedback & cursed typescript fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ testing
 setup/*
 server/logs/*
 cookies.txt
-.vscode
 config/*
 server/build/*
 compose/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "ms-azuretools.vscode-docker",
+      "mongodb.mongodb-vscode",
+      "jeanp413.open-remote-ssh",
+      "styled-components.vscode-styled-components"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "configurations": [
+    {
+      "type": "node-terminal",
+      "name": "Start Server",
+      "request": "launch",
+      "command": "npm run start",
+      "cwd": "${workspaceFolder}/server"
+    },
+    {
+      "type": "node-terminal",
+      "name": "Start Client",
+      "request": "launch",
+      "command": "npm run start",
+      "cwd": "${workspaceFolder}/client"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
       "type": "node-terminal",
       "name": "Start Server",
       "request": "launch",
-      "command": "npm run start",
+      "command": "npm run debug",
       "cwd": "${workspaceFolder}/server"
     },
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.tabSize": 2,
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/server/package.json
+++ b/server/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/typescript/bin/tsc --build",
-    "clean": "./node_modules/typescript/bin/tsc --build --clean",
-    "start": "./node_modules/typescript/bin/tsc --build && node .",
+    "build": "./node_modules/typescript/bin/tsc --build --force",
+    "clean": "./node_modules/typescript/bin/tsc --build --clean --force",
+    "start": "./node_modules/typescript/bin/tsc --build --force && node .",
     "lint": "eslint src --report-unused-disable-directives",
     "go": "node ."
   },

--- a/server/package.json
+++ b/server/package.json
@@ -6,10 +6,10 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "./node_modules/typescript/bin/tsc --build --force",
-    "clean": "./node_modules/typescript/bin/tsc --build --clean --force",
-    "start": "./node_modules/typescript/bin/tsc --build --force && node .",
-    "debug": "./node_modules/typescript/bin/tsc --build --force --sourcemap && node .",
+    "build": "./node_modules/typescript/bin/tsc --build",
+    "clean": "./node_modules/typescript/bin/tsc --build --clean",
+    "start": "./node_modules/typescript/bin/tsc --build && node .",
+    "debug": "./node_modules/typescript/bin/tsc --build --sourcemap && node .",
     "lint": "eslint src --report-unused-disable-directives",
     "go": "node ."
   },

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "build": "./node_modules/typescript/bin/tsc --build --force",
     "clean": "./node_modules/typescript/bin/tsc --build --clean --force",
     "start": "./node_modules/typescript/bin/tsc --build --force && node .",
+    "debug": "./node_modules/typescript/bin/tsc --build --force --sourcemap && node .",
     "lint": "eslint src --report-unused-disable-directives",
     "go": "node ."
   },

--- a/server/src/acquire.ts
+++ b/server/src/acquire.ts
@@ -29,7 +29,6 @@ export default async function fetch(search:string, id = crypto.randomBytes(5).to
         if (result.tracks) {
           resolve(result.tracks);
         } else {
-          logDebug(`acquire worker: ${result.error}`);
           reject(new Error(result.error));
         }
         worker.removeListener('message', action);

--- a/server/src/interactions/commands/play.ts
+++ b/server/src/interactions/commands/play.ts
@@ -91,8 +91,8 @@ export async function execute(interaction:ChatInputCommandInteraction) {
   }
 
   let tracks = await getTracks.catch(async (error:Error) => {
-    log('error', [`play—${internal ? 'db' : 'fetch'} error, ${error.stack}`]);
-    await interaction.editReply({ content: (internal) ? 'OH NO SOMETHING\'S FUCKED' : 'either that\'s a private playlist or SOMETHING\'S FUCKED' });
+    log('error', [`play—${internal ? 'db' : 'fetch'} error, ${error}`]);
+    await interaction.editReply({ content: (internal) ? 'OH NO SOMETHING\'S FUCKED' : (error.message) ? error.message : 'either that\'s a private playlist or SOMETHING\'S FUCKED' });
     if (!internal) { // only external resources exist as pending tracks
       const removed = player.removebyUUID(UUID);
       if (!removed.length) { logDebug(`failed to find/ UUID ${UUID} already removed`); }

--- a/server/src/utilities/dupe_goose_db.js
+++ b/server/src/utilities/dupe_goose_db.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import fs from 'fs';
 import { MongoClient } from 'mongodb';
-import { log } from '../../build/logger.js';
+import { log } from '../logger.js';
 const mongo = JSON.parse(fs.readFileSync(new URL('../../../config.json', import.meta.url))).mongo;
 import chalk from 'chalk';
 const url = mongo.url;

--- a/server/src/webserver.ts
+++ b/server/src/webserver.ts
@@ -185,7 +185,7 @@ worker.on('message', async (message:WebWorkerMessage) => {
             } catch (error:any) {
               log('error', [`webparent queue—fetch error, ${error.stack}`]);
               worker.postMessage({ id:message.id, error: `check that ${query} is't a private playlist` });
-              const removed = await player.removebyUUID(UUID);
+              const removed = player.removebyUUID(UUID);
               if (!removed.length) { logDebug(`webparent queue—failed to find/ UUID ${UUID} already removed`); }
               return;
             }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -18,6 +18,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "sourceMap": true,
     "types": ["node", "spotify-api", "discord.js"]
   },
   "include": [

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -18,7 +18,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "sourceMap": true,
     "types": ["node", "spotify-api", "discord.js"]
   },
   "include": [


### PR DESCRIPTION
this PR makes minor changes to error handling in acquire to allow us to better surface fetch errors. It also adds a few utility files to make development in vscodium easier. Most importantly, this fixes an extremely-cursed issue where typescript would create nested build folders.