### PR TITLE
Better failure handling for acquire

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.tabSize": 2,
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.tsserver.experimental.enableProjectDiagnostics": true
 }

--- a/client/src/TrackSmall.tsx
+++ b/client/src/TrackSmall.tsx
@@ -263,7 +263,6 @@ export function TrackSmall(props: { id:number, track:Track, playerClick:(action:
       rejectDrop();
     }
   };
-  console.log(props.track.goose.track.name);
   return (
     <Wrapper $name={props.track.goose.track.name}>
       <InsertionMarker visible={state.nearerTop} invalid={state.invalid} />

--- a/client/src/TrackSmall.tsx
+++ b/client/src/TrackSmall.tsx
@@ -263,9 +263,9 @@ export function TrackSmall(props: { id:number, track:Track, playerClick:(action:
       rejectDrop();
     }
   };
-
+  console.log(props.track.goose.track.name);
   return (
-    <Wrapper>
+    <Wrapper $name={props.track.goose.track.name}>
       <InsertionMarker visible={state.nearerTop} invalid={state.invalid} />
       <TrackStyle onDragStart={dragStart} onDragEnd={dragEnd} onDragEnter={dragEnter} onDragOver={dragOver} onDragLeave={dragLeave} onDrop={drop}>
         <Art src={props.track.goose.track.art} alt="album art" crossOrigin='anonymous' draggable="false" />
@@ -290,15 +290,19 @@ const TrackStyle = styled.div`
   display: flex;
   height: 8vh;
   align-items: center;
-  background-color: #242627;
-  &:nth-child(even) {background-color: #292b2c;}
-  &:hover {background-color: #303233;}
   width:100%;
 `;
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ $name?:string; }>`
   display: flex;
   flex-direction: column;
+  background-color: ${props => (
+    (props.$name === 'PENDING') ? '#172417' : (props.$name === 'FAILED') ? '#241717' : '#242627'
+  ) };
+  &:nth-child(even) {background-color: ${props => (
+    (props.$name === 'PENDING') ? '#1f301f' : (props.$name === 'FAILED') ? '#311f1f' : '#292b2c'
+  ) };}
+  &:hover {background-color: #303233;}
 `;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -31,7 +31,7 @@
         "validator": "^13.7.0",
         "ws": "^8.17.1",
         "youtube-dl-exec": "^3.0.10",
-        "ytdl-core": "^4.11.2"
+        "ytdl-core": "^4.11.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -38,7 +38,7 @@
     "validator": "^13.7.0",
     "ws": "^8.17.1",
     "youtube-dl-exec": "^3.0.10",
-    "ytdl-core": "^4.11.2"
+    "ytdl-core": "^4.11.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/server/src/interactions/commands/play.ts
+++ b/server/src/interactions/commands/play.ts
@@ -81,10 +81,10 @@ export async function execute(interaction:ChatInputCommandInteraction) {
     getTracks = fetch(search, interaction.id);
     let queueEmbed;
     if (when === 'now' || when === 'next') {
-      ({ UUID } = player.pendingNext(interaction.user.username));
+      ({ UUID } = player.placeholderNext(interaction.user.username));
       queueEmbed = await player.queueEmbed('Pending:', Math.ceil((player.getPlayhead() + 2) / 10));
     } else {
-      ({ UUID, length } = player.pendingLast(interaction.user.username));
+      ({ UUID, length } = player.placeholderLast(interaction.user.username));
       queueEmbed = await player.queueEmbed('Pending:', (Math.ceil((length / 10) || 1)));
     }
     await player.sync(interaction, 'queue', queueEmbed);
@@ -125,7 +125,7 @@ export async function execute(interaction:ChatInputCommandInteraction) {
 
   // only external resources exist as pending tracks
   if (!internal) {
-    const success = player.replacePending(tracks, UUID);
+    const success = player.replacePlaceholder(tracks, UUID);
     if (!success) { // to do: remove this if we decide that pending tracks should not be removeable
       logDebug(`failed to replace UUID ${UUID}, probably deleted`);
       await interaction.editReply({ content:'either you/someone removed your pending track before it resolved or SOMETHING\'S FUCKED' });

--- a/server/src/webserver.ts
+++ b/server/src/webserver.ts
@@ -169,7 +169,7 @@ worker.on('message', async (message:WebWorkerMessage) => {
               return;
             }
 
-            const { UUID } = player.pendingIndex(message.userName, index);
+            const { UUID } = player.placeholderIndex(message.userName, index);
             player.webSync('queue');
             const status = player.getStatus();
             worker.postMessage({ id:message.id, status:status });
@@ -197,7 +197,7 @@ worker.on('message', async (message:WebWorkerMessage) => {
             } else if (length < index) { flag = true; /* handled by splice */ }
             if (flag) { logDebug(`webparent queue—${(index < 0) ? `index negative ${index}` : `index ${index} > ${length}`}. queueing anyway`); }
 
-            const success = player.replacePending(tracks, UUID);
+            const success = player.replacePlaceholder(tracks, UUID);
             if (!success) {
               logDebug(`webparent queue—failed to replace UUID ${UUID}, probably deleted`);
               return;

--- a/server/src/workers/acquire.ts
+++ b/server/src/workers/acquire.ts
@@ -248,14 +248,14 @@ async function fetchTracks(search:string):Promise<Array<Track> | string> {
   await Promise.allSettled(promiseArray).then(promises => {
     for (const promise of promises) {
       if (promise.status === 'fulfilled') { finishedArray.push(promise.value); }
-      if (promise.status === 'rejected') { log('error', ['track assembly promise rejected', JSON.stringify(promise, null, 2)]);}
+      if (promise.status === 'rejected') { log('error', ['track assembly promise rejected:', promise.reason]);}
     }
   });
 
   const lengthCheck = finishedArray.filter((track) => track);
   if (lengthCheck.length === sourceArray.length) {
     return finishedArray;
-  } else { return 'final result does not pass length check'; }
+  } else { return 'acquire: track array assembly failed for at least one track, see the log for details'; }
 }
 
 async function checkTrack(track:TrackSource, type:'spotify' | 'napster'):Promise<Track | null> {
@@ -564,6 +564,8 @@ async function textSource(search:string):Promise<Array<TrackSource | Track | Tra
     log('fetch', [`[0] lack '${ newTrack.name }'`]);
     return Array(newTrack);
   } else {
+    // track wasn't on spotify, go to youtube
+    // TODO - do we want to go to subsonic here first?
     const youtubeTrack = await youtube.fromSearch(search);
     const dbTrack = await db.getTrack({ 'youtube.id': youtubeTrack[0].id });
     if (dbTrack) {

--- a/server/src/workers/acquire.ts
+++ b/server/src/workers/acquire.ts
@@ -39,7 +39,7 @@ async function fetchTracks(search:string):Promise<Array<Track> | string> {
   // if source supports direct playback (youtube, subsonic, soundcloud), return ?
 
   search = search.replace(sanitize, '').trim();
-  let sourceArray:Array<Track | TrackYoutubeSource | TrackSource | {youtube:TrackYoutubeSource, spotify:TrackSource} | TrackYoutubeSource[]> | undefined = undefined;
+  let sourceArray:Array<string | Track | TrackYoutubeSource | TrackSource | {youtube:TrackYoutubeSource, spotify:TrackSource} | TrackYoutubeSource[]> | undefined = undefined;
   let sourceType:'youtube' | 'spotify' | 'napster' | 'subsonic' | 'text' | undefined = undefined;
 
   if (youtubePattern.test(search)) {
@@ -76,6 +76,11 @@ async function fetchTracks(search:string):Promise<Array<Track> | string> {
   for (const track of sourceArray) {
     // build an array of promises so we can return them all at once
     promiseArray.push((async () => {
+      if (typeof track === 'string') {
+        // this track failed to retrieve for some reason, track is a string explaining why
+        // reject the promise to pass the message along
+        return Promise.reject(track);
+      }
       if (!isTrack(track)) {
       // goose does not exist, this is a new track source
       // at this point we should have already checked if we have this track from a different source
@@ -207,8 +212,13 @@ async function fetchTracks(search:string):Promise<Array<Track> | string> {
             query = query.replace(sanitize, '');
             query = query.replace(/(-)+/g, ' ');
             const subsonicResult = await subsonic.fromText(query);
-            let ytArray;
+            let ytArray:Array<TrackYoutubeSource> = [];
             if (!subsonicResult) { ytArray = await youtube.fromSearch(query);}
+            if (!subsonicResult && !ytArray.length) {
+              // subsonic didn't have anything, and all of the youtube tracks filed to return
+              // can't make a track from this, so reject the promise
+              return Promise.reject(`Couldn't find a playable source for ${track.name}; see the logs for more details`);
+            }
             const finishedTrack:Track = {
               goose: {
                 id: await genNewGooseId(),
@@ -224,7 +234,7 @@ async function fetchTracks(search:string):Promise<Array<Track> | string> {
                 },
                 track: {
                   name: track.name,
-                  duration: subsonicResult ? subsonicResult.duration : ytArray![0].duration,
+                  duration: subsonicResult ? subsonicResult.duration : ytArray[0].duration,
                   art: track.art,
                 },
               },
@@ -248,14 +258,19 @@ async function fetchTracks(search:string):Promise<Array<Track> | string> {
   await Promise.allSettled(promiseArray).then(promises => {
     for (const promise of promises) {
       if (promise.status === 'fulfilled') { finishedArray.push(promise.value); }
-      if (promise.status === 'rejected') { log('error', ['track assembly promise rejected:', promise.reason]);}
+      if (promise.status === 'rejected') {
+        log('error', ['track assembly promise rejected:', promise.reason]);
+        if (promise.reason) {
+          finishedArray.push(promise.reason);
+        }
+      }
     }
   });
 
   const lengthCheck = finishedArray.filter((track) => track);
   if (lengthCheck.length === sourceArray.length) {
     return finishedArray;
-  } else { return 'acquire: track array assembly failed for at least one track, see the log for details'; }
+  } else { return 'acquire: track array assembly failed without explanation for at least one track, see the log for details'; }
 }
 
 async function checkTrack(track:TrackSource, type:'spotify' | 'napster'):Promise<Track | null> {
@@ -317,7 +332,7 @@ async function genNewGooseId():Promise<string> {
   return id;
 }
 
-async function youtubeSource(search:string):Promise<Array<TrackYoutubeSource | Track | {youtube:TrackYoutubeSource, spotify:TrackSource}> | undefined> {
+async function youtubeSource(search:string):Promise<Array<TrackYoutubeSource | Track | {youtube:TrackYoutubeSource, spotify:TrackSource} | string> | undefined> {
   // search is a youtube url
   const match = search.match(youtubePattern);
   const track = await db.getTrack({ 'audioSource.youtube.0.id': match![2] });
@@ -327,7 +342,8 @@ async function youtubeSource(search:string):Promise<Array<TrackYoutubeSource | T
   }
   // we don't have this yet - go talk to youtube
   log('fetch', [`[0] lack '${ match![2] }'`]);
-  const source = await youtube.fromId(match![2]);
+  const source = await youtube.fromId(match![2]).catch((e:PromiseRejectedResult) => { return e.reason;});
+  if (typeof source === 'string') { return Array(source); }
   // let's see if spotify knows anything about this track
   // use ContentID info as search parameter, don't perform search if no ContentID match
   const find = source.contentID ? `${source.contentID.name} ${source.contentID.artist}` : null;
@@ -542,7 +558,7 @@ async function subsonicSource(search:string):Promise<Array<TrackSource | Track> 
   }
 }
 
-async function textSource(search:string):Promise<Array<TrackSource | Track | TrackYoutubeSource[]> | undefined> {
+async function textSource(search:string):Promise<Array<string | TrackSource | Track | TrackYoutubeSource[]> | undefined> {
   // search is not any of the url types we recognize, treat as text
   search = search.toLowerCase();
   const track = await db.getTrack({ keys: search });
@@ -566,7 +582,8 @@ async function textSource(search:string):Promise<Array<TrackSource | Track | Tra
   } else {
     // track wasn't on spotify, go to youtube
     // TODO - do we want to go to subsonic here first?
-    const youtubeTrack = await youtube.fromSearch(search);
+    const youtubeTrack = await youtube.fromSearch(search).catch((e:PromiseRejectedResult) => { return e.reason;});
+    if (typeof youtubeTrack === 'string') { return Array(youtubeTrack); }
     const dbTrack = await db.getTrack({ 'youtube.id': youtubeTrack[0].id });
     if (dbTrack) {
       log('fetch', [`[0] have '${ dbTrack.goose.track.name }'`]);

--- a/server/src/workers/acquire/youtube.ts
+++ b/server/src/workers/acquire/youtube.ts
@@ -43,7 +43,7 @@ async function fromSearch(search:string):Promise<Array<TrackYoutubeSource>> {
   await Promise.allSettled(ytPromiseArray).then(promises => {
     for (const promise of promises) {
       if (promise.status === 'fulfilled') { ytArray.push(promise.value); }
-      if (promise.status === 'rejected') { log('error', ['youtube promise rejected', JSON.stringify(promise, null, 2)]);}
+      if (promise.status === 'rejected') { log('error', ['ytdl promise rejected:', promise.reason]);}
     }
   });
   return ytArray;
@@ -76,7 +76,7 @@ async function fromPlaylist(id:string):Promise<Array<TrackYoutubeSource>> {
   await Promise.allSettled(ytPromiseArray).then(promises => {
     for (const promise of promises) {
       if (promise.status === 'fulfilled') { ytArray.push(promise.value); }
-      if (promise.status === 'rejected') { log('error', [JSON.stringify(promise, null, 2)]);}
+      if (promise.status === 'rejected') { log('error', ['ytdl promise rejected:', promise.reason]);}
     }
   });
   return ytArray;


### PR DESCRIPTION
This PR improves acquire error handling, returning somewhat more usable failure messages for ytdl values. It also allows acquire to return partial arrays in cases where only some results of a call failed; to do so, we slightly generify the pending functions in player, allowing for inserting failed track placeholder objects into the queue. In this PR we don't provide any way for players to interact with these outside of what already exists for pending, but this can be improved with time.

This PR also fixes the nth-child display functionality for the web queue.

I haven't tried to chase down all the possible edge-case errors in acquire, there's almost certainly error states that'll crash us or not provide useful feedback; this will need to be improved with time. 

oh and I updated ytdl, though opted not to move to a different package for now as the leading option (distube package) doesn't appear to give us a way to force ipv4; I'm also irritated by their console update-pester that requires setting an env variable to remove.